### PR TITLE
feat: 背景色に画像の特徴色機能を追加

### DIFF
--- a/html/index.html
+++ b/html/index.html
@@ -32,11 +32,17 @@
                             </div>
                         </div>
                         <div class="flex p-4">
-                            <div class="flex items-center h-5">
-                                <input type="checkbox" id="black" name="black" class="checkbox checkbox-primary">
-                                <div class="ms-2 text-sm">
-                                    <label class="label-text">Black</label>
-                                    <p class="text-xs text-base-content">フレームを黒にします</p>
+                            <div class="flex flex-col items-start h-auto">
+                                <div id="color-options">
+                                    <label class="label-text">背景色</label>
+                                    <div class="flex items-center">
+                                        <input type="radio" id="white" name="bgcolor" value="#FFFFFF" class="radio radio-primary" checked>
+                                        <label for="white" class="ml-2">White</label>
+                                    </div>
+                                    <div class="flex items-center">
+                                        <input type="radio" id="black" name="bgcolor" value="#000000" class="radio radio-primary">
+                                        <label for="black" class="ml-2">Black</label>
+                                    </div>
                                 </div>
                             </div>
                         </div>

--- a/html/js/func.js
+++ b/html/js/func.js
@@ -16,11 +16,11 @@ async function callPythonFunction() {
     const input = document.getElementById("inputpath").files[0];
     inputdata = await toBase64DataUri(input);
     const golden = document.getElementById("golden").checked;
-    const black = document.getElementById("black").checked;
+    const bgcolor = document.querySelector('input[name="bgcolor"]:checked').value;
     const rounded = document.getElementById("rounded").checked;
     const maincolor = document.getElementById("maincolor").checked;
 
-    await window.pywebview.api.runFrameMakerFromWebview(inputdata, golden, black, rounded, maincolor).then((response) => {
+    await window.pywebview.api.runFrameMakerFromWebview(inputdata, golden, bgcolor, rounded, maincolor).then((response) => {
         output_image.src = response;
         output_image.classList.remove('hidden');
     });
@@ -30,6 +30,41 @@ async function callPythonFunction() {
     saveButton.innerText = "Save";
 
 }
+
+document.getElementById('inputpath').addEventListener('change', async (event) => {
+    const input = event.target.files[0];
+    if (!input) return;
+
+    const inputdata = await toBase64DataUri(input);
+    const colors = await window.pywebview.api.getMainColorRGBValue(inputdata);
+
+    const colorOptions = document.getElementById('color-options');
+    // Remove existing color options except for black and white
+    const existingOptions = colorOptions.querySelectorAll('.dynamic-color');
+    existingOptions.forEach(option => option.remove());
+
+    colors.forEach((color, index) => {
+        const colorDiv = document.createElement('div');
+        colorDiv.classList.add('flex', 'items-center', 'dynamic-color');
+
+        const radio = document.createElement('input');
+        radio.type = 'radio';
+        radio.id = `color-${index}`;
+        radio.name = 'bgcolor';
+        radio.value = `#${color}`;
+        radio.classList.add('radio', 'radio-primary');
+
+        const label = document.createElement('label');
+        label.htmlFor = `color-${index}`;
+        label.classList.add('ml-2');
+        label.innerText = `#${color}`;
+        label.style.color = `#${color}`;
+
+        colorDiv.appendChild(radio);
+        colorDiv.appendChild(label);
+        colorOptions.appendChild(colorDiv);
+    });
+});
 
 async function saveImage() {
     const output_image = document.getElementById('output-image');

--- a/run_streamlit.py
+++ b/run_streamlit.py
@@ -52,7 +52,7 @@ if uploaded_file:
         with st.spinner("処理中..."):
             # APIを呼び出して画像を処理
             result_data_url = api.runFrameMakerFromWebview(
-                img_data_url, golden, black, True if radius > 0 else False, maincolor, radius
+                img_data_url, golden, "#000000" if black else "#FFFFFF", True if radius > 0 else False, maincolor, radius
             )
             if result_data_url:
                 # 処理結果を表示

--- a/run_streamlit.py
+++ b/run_streamlit.py
@@ -3,8 +3,10 @@ import io
 import base64
 import streamlit as st
 from PIL import Image
+import numpy as np
 from src.WebviewInterface import API
 from dotenv import load_dotenv
+from src.colorpick import getMainColorRGBValue
 
 # 環境変数をロード
 load_dotenv(dotenv_path="./.env")
@@ -25,20 +27,44 @@ st.set_page_config(
 st.title("Frame Maker")
 
 # ファイルアップロード
-uploaded_file = st.sidebar.file_uploader("画像をアップロードしてください", type=["jpg", "jpeg", "png"])
+uploaded_file = st.sidebar.file_uploader(
+    "画像をアップロードしてください", type=["jpg", "jpeg", "png"]
+)
 
 
 # サイドバーでオプションを選択
 st.sidebar.header("オプション設定")
 golden = st.sidebar.checkbox("Golden", help="上下左右の余白を黄金比にします")
-black = st.sidebar.checkbox("Black", help="フレームを黒にします")
-radius = st.sidebar.slider("Radius", min_value=0, value=0, max_value=200, help="画像の角を丸くします")
+radius = st.sidebar.slider(
+    "Radius", min_value=0, value=0, max_value=200, help="画像の角を丸くします"
+)
 maincolor = st.sidebar.checkbox("MainColor", help="画像の最下部に特徴色をつけます")
+
+# 背景色の選択肢
+st.sidebar.subheader("背景色")
+bgcolor_options = {"White": "#FFFFFF", "Black": "#000000"}
+
+if uploaded_file:
+    img = Image.open(uploaded_file)
+    buffered = io.BytesIO()
+    img.save(buffered, format="JPEG")
+    img_base64 = base64.b64encode(buffered.getvalue()).decode("utf-8")
+    img_data_url = f"data:image/jpeg;base64,{img_base64}"
+    main_colors = api.getMainColorRGBValue(img_data_url)
+    for _, color in enumerate(main_colors):
+        bgcolor_options[f"#{color}"] = f"#{color}"
+
+selected_bgcolor_name = st.sidebar.radio("背景色を選択", list(bgcolor_options.keys()))
+bgcolor_to_pass = bgcolor_options[selected_bgcolor_name]
 
 col = st.columns(2)
 if uploaded_file:
     # アップロードされた画像を表示
-    col[0].image(uploaded_file, caption="アップロードされた画像", use_container_width=True, )
+    col[0].image(
+        uploaded_file,
+        caption="アップロードされた画像",
+        use_container_width=True,
+    )
 
     # 画像をBase64形式に変換
     img = Image.open(uploaded_file)
@@ -52,11 +78,18 @@ if uploaded_file:
         with st.spinner("処理中..."):
             # APIを呼び出して画像を処理
             result_data_url = api.runFrameMakerFromWebview(
-                img_data_url, golden, "#000000" if black else "#FFFFFF", True if radius > 0 else False, maincolor, radius
+                img_data_url,
+                golden,
+                bgcolor_to_pass,
+                True if radius > 0 else False,
+                maincolor,
+                radius,
             )
             if result_data_url:
                 # 処理結果を表示
-                col[1].image(result_data_url, caption="処理後の画像", use_container_width=True)
+                col[1].image(
+                    result_data_url, caption="処理後の画像", use_container_width=True
+                )
                 col[1].success("処理が完了しました！")
             else:
                 col[1].error("エラーが発生しました。")

--- a/src/WebviewInterface.py
+++ b/src/WebviewInterface.py
@@ -108,7 +108,7 @@ class API:
         self,
         inputdata: str,
         golden: bool,
-        black: bool,
+        bgcolor: str,
         rounded: bool,
         maincolor: bool,
         radius: int = DEFAULT_RADIUS,
@@ -131,7 +131,7 @@ class API:
             webimg = base64_string_to_pillow_image(inputdata)
             handler = ImageHandler(fp="", webimg=webimg)
             fm = FrameMaker(
-                handler, golden, black, rounded, maincolor, radius=radius, golden_ratio=GOLDEN_RATIO, side_margin_ratio=SIDE_MARGIN_RATIO
+                handler, golden, bgcolor, rounded, maincolor, radius=radius, golden_ratio=GOLDEN_RATIO, side_margin_ratio=SIDE_MARGIN_RATIO
             )
             result = fm.run()
         except ReadError:

--- a/tests/test_FrameMaker.py
+++ b/tests/test_FrameMaker.py
@@ -59,7 +59,7 @@ def test_frame_maker_golden_ratio_white_frame(sample_image_handler_tall):
     期待結果: 出力画像の縦横サイズが期待される黄金比に基づいたサイズであり、フレーム部分が白であること。
     """
     fm = FrameMaker(
-        sample_image_handler_tall, golden=True, black=False, rounded=False, mc=False
+        sample_image_handler_tall, golden=True, bgcolor="#FFFFFF", rounded=False, mc=False
     )
     result_img = fm.run()
 
@@ -85,7 +85,7 @@ def test_frame_maker_golden_ratio_black_frame(sample_image_handler_wide):
     期待結果: 出力画像の縦横サイズが期待される黄金比に基づいたサイズであり、フレーム部分が黒であること。
     """
     fm = FrameMaker(
-        sample_image_handler_wide, golden=True, black=True, rounded=False, mc=False
+        sample_image_handler_wide, golden=True, bgcolor="#000000", rounded=False, mc=False
     )
     result_img = fm.run()
 
@@ -111,7 +111,7 @@ def test_frame_maker_no_golden_ratio_white_frame(sample_image_handler):
     期待結果: 出力画像の縦横サイズが元の画像の最大辺の長さであり、フレーム部分が白であること。
     """
     fm = FrameMaker(
-        sample_image_handler, golden=False, black=False, rounded=False, mc=False
+        sample_image_handler, golden=False, bgcolor="#FFFFFF", rounded=False, mc=False
     )
     result_img = fm.run()
 
@@ -134,7 +134,7 @@ def test_frame_maker_no_golden_ratio_black_frame(sample_image_handler_tall):
     期待結果: 出力画像の縦横サイズが元の画像の最大辺の長さであり、フレーム部分が黒であること。
     """
     fm = FrameMaker(
-        sample_image_handler_tall, golden=False, black=True, rounded=False, mc=False
+        sample_image_handler_tall, golden=False, bgcolor="#000000", rounded=False, mc=False
     )
     result_img = fm.run()
 
@@ -159,7 +159,7 @@ def test_frame_maker_rounded_white_frame(sample_image_handler):
     期待結果: 出力画像のフレーム部分が白であり、角が丸められていること。
     """
     fm = FrameMaker(
-        sample_image_handler, golden=False, black=False, rounded=True, mc=False
+        sample_image_handler, golden=False, bgcolor="#FFFFFF", rounded=True, mc=False
     )
     result_img = fm.run()
 
@@ -175,7 +175,7 @@ def test_frame_maker_rounded_black_frame(sample_image_handler):
     期待結果: 出力画像のフレーム部分が黒であり、角が丸められていること。
     """
     fm = FrameMaker(
-        sample_image_handler, golden=False, black=True, rounded=True, mc=False
+        sample_image_handler, golden=False, bgcolor="#000000", rounded=True, mc=False
     )
     result_img = fm.run()
 
@@ -191,7 +191,7 @@ def test_frame_maker_main_color_bar(sample_image_handler_colored):
     期待結果: 出力画像にカラーバーが追加され、その領域が完全に白ではないこと。
     """
     fm = FrameMaker(
-        sample_image_handler_colored, golden=False, black=False, rounded=False, mc=True
+        sample_image_handler_colored, golden=False, bgcolor="#FFFFFF", rounded=False, mc=True
     )
     result_img = fm.run()
 
@@ -211,7 +211,7 @@ def test_frame_maker_rounded_and_main_color_bar(sample_image_handler_colored):
     期待結果: 出力画像の角が丸められ、カラーバーが追加され、その領域が完全に白ではないこと。
     """
     fm = FrameMaker(
-        sample_image_handler_colored, golden=False, black=False, rounded=True, mc=True
+        sample_image_handler_colored, golden=False, bgcolor="#FFFFFF", rounded=True, mc=True
     )
     result_img = fm.run()
 

--- a/tests/test_FrameMaker.py
+++ b/tests/test_FrameMaker.py
@@ -59,7 +59,11 @@ def test_frame_maker_golden_ratio_white_frame(sample_image_handler_tall):
     期待結果: 出力画像の縦横サイズが期待される黄金比に基づいたサイズであり、フレーム部分が白であること。
     """
     fm = FrameMaker(
-        sample_image_handler_tall, golden=True, bgcolor="#FFFFFF", rounded=False, mc=False
+        sample_image_handler_tall,
+        golden=True,
+        bgcolor="#FFFFFF",
+        rounded=False,
+        mc=False,
     )
     result_img = fm.run()
 
@@ -85,7 +89,11 @@ def test_frame_maker_golden_ratio_black_frame(sample_image_handler_wide):
     期待結果: 出力画像の縦横サイズが期待される黄金比に基づいたサイズであり、フレーム部分が黒であること。
     """
     fm = FrameMaker(
-        sample_image_handler_wide, golden=True, bgcolor="#000000", rounded=False, mc=False
+        sample_image_handler_wide,
+        golden=True,
+        bgcolor="#000000",
+        rounded=False,
+        mc=False,
     )
     result_img = fm.run()
 
@@ -134,7 +142,11 @@ def test_frame_maker_no_golden_ratio_black_frame(sample_image_handler_tall):
     期待結果: 出力画像の縦横サイズが元の画像の最大辺の長さであり、フレーム部分が黒であること。
     """
     fm = FrameMaker(
-        sample_image_handler_tall, golden=False, bgcolor="#000000", rounded=False, mc=False
+        sample_image_handler_tall,
+        golden=False,
+        bgcolor="#000000",
+        rounded=False,
+        mc=False,
     )
     result_img = fm.run()
 
@@ -191,7 +203,11 @@ def test_frame_maker_main_color_bar(sample_image_handler_colored):
     期待結果: 出力画像にカラーバーが追加され、その領域が完全に白ではないこと。
     """
     fm = FrameMaker(
-        sample_image_handler_colored, golden=False, bgcolor="#FFFFFF", rounded=False, mc=True
+        sample_image_handler_colored,
+        golden=False,
+        bgcolor="#FFFFFF",
+        rounded=False,
+        mc=True,
     )
     result_img = fm.run()
 
@@ -211,7 +227,11 @@ def test_frame_maker_rounded_and_main_color_bar(sample_image_handler_colored):
     期待結果: 出力画像の角が丸められ、カラーバーが追加され、その領域が完全に白ではないこと。
     """
     fm = FrameMaker(
-        sample_image_handler_colored, golden=False, bgcolor="#FFFFFF", rounded=True, mc=True
+        sample_image_handler_colored,
+        golden=False,
+        bgcolor="#FFFFFF",
+        rounded=True,
+        mc=True,
     )
     result_img = fm.run()
 
@@ -224,3 +244,20 @@ def test_frame_maker_rounded_and_main_color_bar(sample_image_handler_colored):
     # カラーバーの領域が完全に白ではないことを確認
     color_bar_area = result_img[result_img.shape[0] - expected_pick_height :, :]
     assert not np.all(color_bar_area == 255)
+
+
+def test_frame_maker_custom_background_color(sample_image_handler):
+    """
+    カスタム背景色が正しく適用されることを確認する。
+
+    テスト対象機能: FrameMakerのbgcolorオプション
+    期待結果: 出力画像のフレーム部分が指定された色（赤）であること。
+    """
+    fm = FrameMaker(
+        sample_image_handler, golden=True, bgcolor="#FF0000", rounded=False, mc=False
+    )
+    result_img = fm.run()
+
+    # フレーム部分が赤であることを確認（例：角のピクセル）
+    # OpenCVはBGR順なので、(0, 0, 255)が赤に対応
+    assert np.all(result_img[0, 0] == [0, 0, 255])


### PR DESCRIPTION
Closes #21

## 概要

このプルリクエストは、画像から特徴的な色（ドミナントカラー）を抽出し、その色を背景色として設定する機能を追加するものです。

## 主な変更点

- **背景色オプションの拡張:**
  - `FrameMaker`クラスで、背景色を真偽値（白黒）で指定する代わりに、16進数のカラーコードで指定できるように変更しました。
- **特徴色の抽出と適用:**
  - Streamlitアプリケーション (`run_streamlit.py`) に、画像の最も代表的な色を抽出し、背景色として設定する機能を追加しました。
- **UIの更新:**
  - Webview (`html/index.html`, `html/js/func.js`) および `WebviewInterface` を更新し、新しい背景色オプションに対応しました。
- **テストの更新と追加:**
  - `FrameMaker`のテストを、`bgcolor`の変更に合わせて更新しました。
  - カスタムカラーコードが正しく適用されることを確認するための新しいテストケースを追加しました。